### PR TITLE
🪲 Fix for preview mode

### DIFF
--- a/client/src/Views/Components/CreateNoteModal/index.tsx
+++ b/client/src/Views/Components/CreateNoteModal/index.tsx
@@ -14,12 +14,7 @@ import MDPreview from '../MDPreview'
 import { useAppDispatch, useAppSelector } from '../../../Services/Store'
 import { setNotes } from '../../../Services/Reducers/noteSlice'
 import { setModalState } from '../../../Services/Reducers/modalSlice'
-import {
-  CloseButton,
-  DescInput,
-  SubmitButton,
-  TitleInput,
-} from './CustomInputs'
+import { CloseButton, DescInput, SubmitButton, TitleInput } from './CustomInputs'
 
 const useStyles = (wideView: boolean) =>
   makeStyles<Theme>(
@@ -53,9 +48,7 @@ const modalStyle = (darkMode: boolean) => ({
 })
 
 const CreateNoteModal: React.FC = () => {
-  const { darkMode, mdMode, previewMode } = useAppSelector(
-    ({ settings }) => settings,
-  )
+  const { darkMode, mdMode, previewMode } = useAppSelector(({ settings }) => settings)
   const { noteState } = useAppSelector(({ notes }) => notes)
   const {
     modalState: { editingNoteId, open },
@@ -71,9 +64,7 @@ const CreateNoteModal: React.FC = () => {
 
   const classes = useStyles(wideView)()
 
-  const editingNote = noteState.find(
-    (note: NoteItem) => note.id === editingNoteId,
-  )
+  const editingNote = noteState.find((note: NoteItem) => note.id === editingNoteId)
 
   const [primary, setPrimary] = useState<string>('')
   const [secondary, setSecondary] = useState<string>('')
@@ -84,9 +75,7 @@ const CreateNoteModal: React.FC = () => {
   }, [editingNote, open])
 
   const handleClose = (): void => {
-    dispatch(
-      setModalState({ modalState: { open: false, editingNoteId: null } }),
-    )
+    dispatch(setModalState({ modalState: { open: false, editingNoteId: null } }))
   }
 
   const titleProps = { setPrimary, primary }
@@ -106,9 +95,7 @@ const CreateNoteModal: React.FC = () => {
     }
 
     bigLog(`Updated note: ${editingNoteId}`)
-    const indOfNote = noteState.findIndex(
-      (note: NoteItem) => note.id === editingNoteId,
-    )
+    const indOfNote = noteState.findIndex((note: NoteItem) => note.id === editingNoteId)
     const newNotes = [...noteState]
     newNotes[indOfNote] = {
       ...newNotes[indOfNote],
@@ -167,9 +154,7 @@ const CreateNoteModal: React.FC = () => {
     return (
       <div
         style={{
-          border: `solid 1px rgba(${
-            darkMode ? '255, 255, 255, 25%' : '0, 0, 0, 25%'
-          })`,
+          border: `solid 1px rgba(${darkMode ? '255, 255, 255, 25%' : '0, 0, 0, 25%'})`,
           borderRadius: '4px',
           paddingRight: '0.3rem',
         }}
@@ -212,9 +197,7 @@ const CreateNoteModal: React.FC = () => {
                 />
               )}
             </FormGroup>
-            {showPreview && (
-              <MDPreview darkMode={darkMode}>{secondary}</MDPreview>
-            )}
+            {showPreview && <MDPreview darkMode={darkMode}>{secondary}</MDPreview>}
           </div>
         </Scrollbars>
       </div>
@@ -233,10 +216,7 @@ const CreateNoteModal: React.FC = () => {
         <TitleInput {...titleProps} />
         <DescInput {...descProps} />
         <CloseButton {...noteButtonProps} />
-        <SubmitButton
-          {...submitButtonProps}
-          editingNoteID={editingNoteId ?? undefined}
-        />
+        <SubmitButton {...submitButtonProps} editingNoteID={editingNoteId ?? undefined} />
         {mdMode && !isMobile && <MDContainer />}
       </form>
       <span id="new-note-modal" style={{ display: 'none' }} aria-hidden="true">

--- a/client/src/Views/Components/CreateNoteModal/index.tsx
+++ b/client/src/Views/Components/CreateNoteModal/index.tsx
@@ -65,6 +65,10 @@ const CreateNoteModal: React.FC = () => {
   const [wideView, toggleWideView] = useState<boolean>(false)
   const [showPreview, togglePreview] = useState<boolean>(previewMode)
 
+  useEffect(() => {
+    togglePreview(previewMode)
+  }, [previewMode])
+
   const classes = useStyles(wideView)()
 
   const editingNote = noteState.find(


### PR DESCRIPTION
## Problem

The "Always Show Preview" toggle does not work

## Solution

Added a hook which causes the create note modal to re-render when the toggle value changes.

The menu toggle now correctly overrides the Create Note Modal setting & reacts appropriately to state changes from the toggle.